### PR TITLE
changed editText's alpha in reduce method()

### DIFF
--- a/materialtextfield/src/main/java/com/github/florent37/materialtextfield/MaterialTextField.java
+++ b/materialtextfield/src/main/java/com/github/florent37/materialtextfield/MaterialTextField.java
@@ -78,7 +78,7 @@ public class MaterialTextField extends FrameLayout {
                 .setDuration(ANIMATION_DURATION);
 
             ViewCompat.animate(editText)
-                .alpha(0f)
+                .alpha(1f)
                 .setUpdateListener(new ViewPropertyAnimatorUpdateListener() {
                     @Override
                     public void onAnimationUpdate(View view) {


### PR DESCRIPTION
Previously editText was being invisible when collapsed as in reduce method alpha was set to 0. Changing that alpha value to 1 solves the issue
